### PR TITLE
fix: 各画面ヘッダーの日本語表示・幅調整

### DIFF
--- a/src/scenes/PostDetail.js
+++ b/src/scenes/PostDetail.js
@@ -150,7 +150,7 @@ const PostInfo = ({navigation}) => {
   const {post, products, isLoading, masterData} = useSelector(({postDetail: {post, products, isLoading}, app: {masterData}}) => ({post, products, isLoading, masterData}))
   const labelMap = Object.fromEntries(displayItemsList.map(key => [key, parseMasterData(masterData, key, "object")]))
   const styles = createStyles(post.isLike)
-  
+
   return (
     <>
       <View style={styles.infoContainer}>
@@ -177,7 +177,7 @@ const ReactionContainer = ({navigation}) => {
   const styles = createStyles()
   const dispatch = useDispatch()
   const {post, user_id} = useSelector(({postDetail: {post}, auth: {user: {user_id}}}) => ({post, user_id}))
-  
+
   return (
     <View style={styles.infoContainer}>
       <View style={styles.centerAlignment}>

--- a/src/scenes/PostDetail.js
+++ b/src/scenes/PostDetail.js
@@ -150,8 +150,6 @@ const PostInfo = ({navigation}) => {
   const {post, products, isLoading, masterData} = useSelector(({postDetail: {post, products, isLoading}, app: {masterData}}) => ({post, products, isLoading, masterData}))
   const labelMap = Object.fromEntries(displayItemsList.map(key => [key, parseMasterData(masterData, key, "object")]))
   const styles = createStyles(post.isLike)
-
-  //console.log("日付のログ"+post.DateTime)
   
   return (
     <>
@@ -167,7 +165,7 @@ const PostInfo = ({navigation}) => {
           <Title style={styles.tagTitle}>タグ</Title>
           {post.tags.length > 0 ? <ChipList items={post.tags.map(tag => ({label: "#" + tag}))} /> : <Text style={styles.marginLeft}>情報なし</Text>}
         </View>
-        <IconLabel icon="clock" color="#000" style={styles.postTime}>{post.DateTime ? post.DateTime.replace("T", " ").slice(0, -8) : "" }</IconLabel>
+        <IconLabel icon="clock" color="#000" style={styles.postTime}>{post.DateTime ? post.DateTime.replace("T", " ").slice(0, -8) : ""}</IconLabel>
       </View>
       <Loading isLoading={isLoading} />
     </>

--- a/src/scenes/PostDetail.js
+++ b/src/scenes/PostDetail.js
@@ -151,6 +151,8 @@ const PostInfo = ({navigation}) => {
   const labelMap = Object.fromEntries(displayItemsList.map(key => [key, parseMasterData(masterData, key, "object")]))
   const styles = createStyles(post.isLike)
 
+  //console.log("日付のログ"+post.DateTime)
+  
   return (
     <>
       <View style={styles.infoContainer}>
@@ -165,7 +167,7 @@ const PostInfo = ({navigation}) => {
           <Title style={styles.tagTitle}>タグ</Title>
           {post.tags.length > 0 ? <ChipList items={post.tags.map(tag => ({label: "#" + tag}))} /> : <Text style={styles.marginLeft}>情報なし</Text>}
         </View>
-        <IconLabel icon="clock" color="#000" style={styles.postTime}>{post.DateTime ? post.DateTime.replace("T", " ").slice(0, -8) : ""}</IconLabel>
+        <IconLabel icon="clock" color="#000" style={styles.postTime}>{post.DateTime ? post.DateTime.replace("T", " ").slice(0, -8) : "" }</IconLabel>
       </View>
       <Loading isLoading={isLoading} />
     </>

--- a/src/screens/MyPageScreen.js
+++ b/src/screens/MyPageScreen.js
@@ -41,7 +41,7 @@ const navigatorProps = ({
   initialRouteName: "MyPage",
   screenOptions: {
     headerStyle: {height: WINDOW_HEIGHT > 600 ? 100 : 70},
-    headerTitleStyle: {width: "70%"},
+    headerTitleStyle: {width: "100%"},
     headerTitleAlign: "left",
     headerBackTitleVisible: false
   }
@@ -52,18 +52,25 @@ export const MyPageScreen = () => {
   return (
     <Stack.Navigator {...navigatorProps}>
       {/* eslint-disable-next-line react/display-name */}
-      <Stack.Screen name="MyPage" component={UserPage} initialParams={{isMyPage: true}} options={({navigation}) => ({headerRight: () => <HeaderRightIcons navigation={navigation} />})} />
+      <Stack.Screen 
+        name="MyPage" 
+        component={UserPage} 
+        initialParams={{isMyPage: true}} 
+        options={({navigation}) => ({headerRight: () => <HeaderRightIcons navigation={navigation} />,
+        title: 'マイページ'
+        })} 
+      />
       <Stack.Screen name="UserHome" component={UserPage} />
       <Stack.Screen name="PostDetail" component={PostDetail} />
-      <Stack.Screen name="UserInfoSetting" component={UserInfoSetting} />
-      <Stack.Screen name="NoticeSetting" component={NoticeSetting} />
-      <Stack.Screen name="Settings" component={Settings} />
-      <Stack.Screen name="TermsOfService" component={TermsOfService} />
-      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicy} />
-      <Stack.Screen name="ChangePassword" component={ChangePassword} />
-      <Stack.Screen name="ChangeMail" component={ChangeMail} />
-      <Stack.Screen name="SavedPosts" component={SavedPosts} />
-      <Stack.Screen name="BlockedUsers" component={BlockedUsers} />
+      <Stack.Screen name="UserInfoSetting" component={UserInfoSetting} options={{title:'プロフィール設定'}}/>
+      <Stack.Screen name="NoticeSetting" component={NoticeSetting} options={{title:'通知設定'}}/>
+      <Stack.Screen name="Settings" component={Settings} options={{title:'設定'}}/>
+      <Stack.Screen name="TermsOfService" component={TermsOfService} options={{title:'利用規約'}}/>
+      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicy} options={{title:'プライベートポリシー'}}/>
+      <Stack.Screen name="ChangePassword" component={ChangePassword} options={{title:'パスワード変更'}}/>
+      <Stack.Screen name="ChangeMail" component={ChangeMail} options={{title:'メールアドレス変更'}}/>
+      <Stack.Screen name="SavedPosts" component={SavedPosts} options={{title:'保存済み'}}/>
+      <Stack.Screen name="BlockedUsers" component={BlockedUsers} options={{title:'ブロックしたユーザー一覧'}}/>
     </Stack.Navigator>
   )
 }

--- a/src/screens/MyPageScreen.js
+++ b/src/screens/MyPageScreen.js
@@ -56,21 +56,22 @@ export const MyPageScreen = () => {
         name="MyPage" 
         component={UserPage} 
         initialParams={{isMyPage: true}} 
-        options={({navigation}) => ({headerRight: () => <HeaderRightIcons navigation={navigation} />,
-        title: 'マイページ'
+        options={({navigation}) => ({
+          headerRight: () => <HeaderRightIcons navigation={navigation} />,
+          title: "マイページ"
         })} 
       />
       <Stack.Screen name="UserHome" component={UserPage} />
       <Stack.Screen name="PostDetail" component={PostDetail} />
-      <Stack.Screen name="UserInfoSetting" component={UserInfoSetting} options={{title:'プロフィール設定'}}/>
-      <Stack.Screen name="NoticeSetting" component={NoticeSetting} options={{title:'通知設定'}}/>
-      <Stack.Screen name="Settings" component={Settings} options={{title:'設定'}}/>
-      <Stack.Screen name="TermsOfService" component={TermsOfService} options={{title:'利用規約'}}/>
-      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicy} options={{title:'プライベートポリシー'}}/>
-      <Stack.Screen name="ChangePassword" component={ChangePassword} options={{title:'パスワード変更'}}/>
-      <Stack.Screen name="ChangeMail" component={ChangeMail} options={{title:'メールアドレス変更'}}/>
-      <Stack.Screen name="SavedPosts" component={SavedPosts} options={{title:'保存済み'}}/>
-      <Stack.Screen name="BlockedUsers" component={BlockedUsers} options={{title:'ブロックしたユーザー一覧'}}/>
+      <Stack.Screen name="UserInfoSetting" component={UserInfoSetting} options={{title:"プロフィール設定"}}/>
+      <Stack.Screen name="NoticeSetting" component={NoticeSetting} options={{title:"通知設定"}}/>
+      <Stack.Screen name="Settings" component={Settings} options={{title:"設定"}}/>
+      <Stack.Screen name="TermsOfService" component={TermsOfService} options={{title:"利用規約"}}/>
+      <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicy} options={{title:"プライベートポリシー"}}/>
+      <Stack.Screen name="ChangePassword" component={ChangePassword} options={{title:"パスワード変更"}}/>
+      <Stack.Screen name="ChangeMail" component={ChangeMail} options={{title:"メールアドレス変更"}}/>
+      <Stack.Screen name="SavedPosts" component={SavedPosts} options={{title:"保存済み"}}/>
+      <Stack.Screen name="BlockedUsers" component={BlockedUsers} options={{title:"ブロックしたユーザー一覧"}}/>
     </Stack.Navigator>
   )
 }

--- a/src/screens/NoticeScreen.js
+++ b/src/screens/NoticeScreen.js
@@ -18,7 +18,7 @@ const navigatorProps = ({
 export const NoticeScreen = () => {
   return (
     <Stack.Navigator {...navigatorProps}>
-      <Stack.Screen name="Notice" component={Notice} />
+      <Stack.Screen name="Notice" component={Notice} options={{title: 'お知らせ'}}/>
     </Stack.Navigator>
   )
 }

--- a/src/screens/PostScreen.js
+++ b/src/screens/PostScreen.js
@@ -33,7 +33,7 @@ const SelectProducts = props => {
 export const PostScreen = () => {
   return (
     <Stack.Navigator {...navigatorProps}>
-      <Stack.Screen name="SelectImages" component={SelectImages} />
+      <Stack.Screen name="SelectImages" component={SelectImages} options={{title:'新規投稿'}}/>
       <Stack.Screen name="SelectProducts" component={SelectProducts} />
       <Stack.Screen name="SelectTags" component={SelectTags} />
     </Stack.Navigator>

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -53,7 +53,7 @@ export const SearchScreen = ({navigation}) => {
       <Stack.Screen name="Search" component={Search} options={{
         ...defaultScreenOptions,
         headerRight: () => <Text onPress={() => resetTmpConditions(dispatch)}>条件クリア</Text>,
-        title: '検索',
+        title: "検索"
       }}/>
       <Stack.Screen name="SelectTags" component={SelectTags} />
       <Stack.Screen name="SelectProducts" component={SelectProducts} />
@@ -62,7 +62,7 @@ export const SearchScreen = ({navigation}) => {
         headerRight: false,
         headerLeft: false,
         headerTitleContainerStyle: { 
-          width: "100%",
+          width: "100%"
         },
         headerTitle: () => <FakeInput placeholder={TAG_SEARCH_PLACE_HOLDER} navigation={navigation} value={tmpConditions.tags.join(" ")} style={{maxHeight: 35}} />,
         gestureDirection: "horizontal-inverted"
@@ -70,7 +70,7 @@ export const SearchScreen = ({navigation}) => {
       <Stack.Screen name="PostDetail" component={PostDetail} options={{
         ...defaultScreenOptions,
         headerRight: false,
-        title:'投稿'
+        title:"投稿"
       }} />
       <Stack.Screen name="ProductDetail" component={ProductDetail} options={defaultScreenOptions} />
       <Stack.Screen name="UserHome" component={UserPage} options={{
@@ -85,7 +85,7 @@ export const SearchScreen = ({navigation}) => {
             height: 0
           }
         },
-        title:'検索結果'
+        title:"検索結果"
       }} />
       <Stack.Screen name="Comments" component={Comments} options={defaultScreenOptions} />
     </Stack.Navigator>

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -69,7 +69,8 @@ export const SearchScreen = ({navigation}) => {
       }}/>
       <Stack.Screen name="PostDetail" component={PostDetail} options={{
         ...defaultScreenOptions,
-        headerRight: false
+        headerRight: false,
+        title:'投稿'
       }} />
       <Stack.Screen name="ProductDetail" component={ProductDetail} options={defaultScreenOptions} />
       <Stack.Screen name="UserHome" component={UserPage} options={{

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -26,7 +26,7 @@ const navigatorProps = ({
   initialRouteName: "NewsFeed",
   screenOptions: {
     headerStyle: {height: WINDOW_HEIGHT > 600 ? 100 : 70},
-    headerTitleStyle: {width: "70%"},
+    headerTitleStyle: {width: "100%"},
     headerTitleAlign: "left",
     headerBackTitleVisible: false
   }
@@ -52,7 +52,8 @@ export const SearchScreen = ({navigation}) => {
     <Stack.Navigator {...navigatorProps}>
       <Stack.Screen name="Search" component={Search} options={{
         ...defaultScreenOptions,
-        headerRight: () => <Text onPress={() => resetTmpConditions(dispatch)}>条件クリア</Text>
+        headerRight: () => <Text onPress={() => resetTmpConditions(dispatch)}>条件クリア</Text>,
+        title: '検索',
       }}/>
       <Stack.Screen name="SelectTags" component={SelectTags} />
       <Stack.Screen name="SelectProducts" component={SelectProducts} />
@@ -82,7 +83,8 @@ export const SearchScreen = ({navigation}) => {
           shadowOffset: {
             height: 0
           }
-        }
+        },
+        title:'検索結果'
       }} />
       <Stack.Screen name="Comments" component={Comments} options={defaultScreenOptions} />
     </Stack.Navigator>


### PR DESCRIPTION
以下画面ヘッダーの、表示と幅調整。
・マイページ
・お知らせ
・検索
・検索結果
・新規投稿
・マイページ→設定画面の各種